### PR TITLE
remove grep around source

### DIFF
--- a/jenkinslint
+++ b/jenkinslint
@@ -33,7 +33,7 @@ fi
 
 # Read INI file if it exists
 # shellcheck disable=SC1090
-[[ -f "${INIFILE}" ]] && source <(grep "=" "${INIFILE}")
+[[ -f "${INIFILE}" ]] && source "${INIFILE}"
 
 JENKINS_FILE=${1:-Jenkinsfile}
 if [ ! -f "${JENKINS_FILE}" ]; then


### PR DESCRIPTION
This does not seem to work on macOS's version of bash so remove this and just source it in.