### PR TITLE
Remove unneeded quotes around JENKINS_UNSAFE_SSL

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 ---
 - id: jenkinslint
-  name: Lint Jenkinsfile
+  name: Lint Jenkinsfiles
   description: Validates Jenkinsfiles using a Jenkins server
   entry: jenkinslint
   language: script
-  files: ^Jenkinsfile
+  types: [file, jenkins]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-## 1.0.0 (2020-07-10)
+## 1.0.1 (2024-12-16)
 
+* do not wrap quotes around empty argument
+
+* allow linting multiple jenkinsfiles
+
+## 1.0.0 (2020-07-10)
 
 ### Bug Fixes
 

--- a/README.rst
+++ b/README.rst
@@ -39,12 +39,12 @@ Not all parameters need to be set. Example:
 Standalone
 ----------
 
-Validate files using ``jenkinslint`` followed by the name of the Jenkinsfile,
+Validate files using ``jenkinslint`` followed by a list of Jenkinsfiles,
 e.g.
 
 ::
 
-   jenkinslint Jenkinsfile
+   jenkinslint Jenkinsfile a.jenkins b.jenkinsfile
 
 Using the pre-commit framework
 ------------------------------
@@ -55,10 +55,9 @@ Install the pre-commit framework, and add the following to the
 ::
 
     - repo: https://github.com/PeterMosmans/jenkinslint
-      rev: master
+      rev: v1.0.0
       hooks:
        - id: jenkinslint
 
-This will automatically validate files named ``Jenkinsfile`` during the pre
-commit phase.
-
+This will automatically validate files named ``Jenkinsfile, *.jenkins or
+*.jenkinsfile`` during the pre commit phase.

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Install the pre-commit framework, and add the following to the
 ::
 
     - repo: https://github.com/PeterMosmans/jenkinslint
-      rev: v1.0.0
+      rev: v1.0.1
       hooks:
        - id: jenkinslint
 

--- a/jenkinslint
+++ b/jenkinslint
@@ -35,18 +35,11 @@ fi
 # shellcheck disable=SC1090
 [[ -f "${INIFILE}" ]] && source "${INIFILE}"
 
-JENKINS_FILE=${1:-Jenkinsfile}
-if [ ! -f "${JENKINS_FILE}" ]; then
-    echo "Could not find file ${JENKINS_FILE}"
-    exit 1
-else
-    echo "Validating ${JENKINS_FILE}"
-fi
-
 # Disable certificate validation when JENKINS_UNSAFE_SSL parameter is defined
 [[ -n "${JENKINS_UNSAFE_SSL}" ]] && JENKINS_UNSAFE_SSL="-k"
 
 ssh_validation(){
+    JENKINS_FILE=$1
     result=$(ssh "${JENKINS_SERVER}" -p "${JENKINS_SSH_PORT}" declarative-linter < "${JENKINS_FILE}")
     return=$?
     if [[ $return -ge 2 ]]; then
@@ -72,6 +65,7 @@ show_settings(){
 }
 
 web_validation(){
+    JENKINS_FILE=$1
     JENKINS_CRUMB=$(curl ${JENKINS_UNSAFE_SSL} -s -m 5 "$JENKINS_URL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)")
     return=$?
     if [ $return -ne 0 ]; then
@@ -92,16 +86,35 @@ web_validation(){
 validate(){
     if [[ $result =~ Errors ]]; then
         echo "$result"
-        exit 1
+        ERROR=true
     else
         echo "$result"
-        exit 0
     fi
 }
 
-if [[ "$JENKINS_SSH_PORT" ]]; then
-    ssh_validation
-else
-    web_validation
+ERROR=false
+
+JENKINS_FILE_LIST=("${@}")
+if [[ $# == 0 ]]; then
+    # Default to file named Jenkinsfile if no arguments are supplied
+    JENKINS_FILE_LIST+=("Jenkinsfile")
 fi
-validate
+
+for jenkinsfile in "${JENKINS_FILE_LIST[@]}"; do
+    if [ ! -f "${jenkinsfile}" ]; then
+        echo "Could not find file ${jenkinsfile}"
+    else
+        echo "Linting ${jenkinsfile} ..."
+        if [[ "$JENKINS_SSH_PORT" ]]; then
+            ssh_validation "$jenkinsfile"
+        else
+            web_validation "$jenkinsfile"
+        fi
+        validate
+    fi
+done
+
+if [[ $ERROR == "true" ]]; then
+    exit 1
+fi
+exit 0

--- a/jenkinslint
+++ b/jenkinslint
@@ -66,7 +66,7 @@ show_settings(){
 
 web_validation(){
     JENKINS_FILE=$1
-    JENKINS_CRUMB=$(curl ${JENKINS_UNSAFE_SSL} -s -m 5 "$JENKINS_URL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)")
+    JENKINS_CRUMB=$(curl ${JENKINS_UNSAFE_SSL} --show-error -s -m 30 "$JENKINS_URL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)")
     return=$?
     if [ $return -ne 0 ]; then
         echo "Could not connect to $JENKINS_URL"
@@ -80,7 +80,7 @@ web_validation(){
         show_settings
         exit 1
     fi
-    result=$(curl ${JENKINS_UNSAFE_SSL} -sX POST -H "${JENKINS_CRUMB}" -F "jenkinsfile=<${JENKINS_FILE}" "${JENKINS_URL}/pipeline-model-converter/validate")
+    result=$(curl ${JENKINS_UNSAFE_SSL} --show-error -sX POST -H "${JENKINS_CRUMB}" -F "jenkinsfile=<${JENKINS_FILE}" "${JENKINS_URL}/pipeline-model-converter/validate")
 }
 
 validate(){

--- a/jenkinslint
+++ b/jenkinslint
@@ -86,7 +86,7 @@ web_validation(){
         show_settings
         exit 1
     fi
-    result=$(curl "${JENKINS_UNSAFE_SSL}" -sX POST -H "${JENKINS_CRUMB}" -F "jenkinsfile=<${JENKINS_FILE}" "${JENKINS_URL}/pipeline-model-converter/validate")
+    result=$(curl ${JENKINS_UNSAFE_SSL} -sX POST -H "${JENKINS_CRUMB}" -F "jenkinsfile=<${JENKINS_FILE}" "${JENKINS_URL}/pipeline-model-converter/validate")
 }
 
 validate(){


### PR DESCRIPTION
Having quotes around this argument (especially if it is empty) in curl (tested on curl 8.7.1 (x86_64-apple-darwin24.0)) causes 
```
curl: option : blank argument where content is expected
curl: try 'curl --help' or 'curl --manual' for more information
```